### PR TITLE
:bug: Fix ResettableTimer to run as daemon=True

### DIFF
--- a/octoprint_dashboard/__init__.py
+++ b/octoprint_dashboard/__init__.py
@@ -81,7 +81,7 @@ class DashboardPlugin(octoprint.plugin.SettingsPlugin,
             #self._logger.info("Result: " + result)
             self.cmd_results.append(result)
         self._plugin_manager.send_plugin_message(self._identifier, dict(cmdResults=json.dumps(self.cmd_results)))
-        t = ResettableTimer(60.0, self.cmdGetStats)
+        t = ResettableTimer(60.0, self.cmdGetStats, daemon=True)
         t.start()
 
 


### PR DESCRIPTION
Should solve #214, there may be others and I will test it later. PR created against your development branch since I assume master is the latest release.

It doesn't want to automatically merge, but this shows you the problem. It might need a rebase against your development branch, but I can't do that now. Give it a couple of hours and I might have a chance.

I will also ask if this can be set as default in the class in OctoPrint, to avoid issues like this in the future.