### PR TITLE
Fix daemon 2nd try

### DIFF
--- a/octoprint_dashboard/__init__.py
+++ b/octoprint_dashboard/__init__.py
@@ -83,7 +83,8 @@ class DashboardPlugin(octoprint.plugin.SettingsPlugin,
 			#self._logger.info("Result: " + result)
 			self.cmd_results.append(result)
 		self._plugin_manager.send_plugin_message(self._identifier, dict(cmdResults=json.dumps(self.cmd_results)))
-		t = ResettableTimer(60.0, self.cmdGetStats, daemon=True)
+		t = ResettableTimer(60.0, self.cmdGetStats)
+		t.daemon = True
 		t.start()
 
 


### PR DESCRIPTION
Actually fix the daemon threading now...

Really sorry about that! It worked when I tested since I had added in the kwarg that's in my PR to OctoPrint, didn't check the log to see that the timer is not actually started since daemon was an unexpected kwarg. Actually fixed now. I get mixed up what I have installed where....

It *actually* works this time, verified that the plugin loads properly and that there are no errors, on a 1.4.2 install.