### PR TITLE
Disable webcam stream if dashboard tab is not active

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The dashboard uses the time estimates provided by PrintTimeGenius if it is insta
 * Chartist chart framework: https://gionkunz.github.io/chartist-js/ [license](https://github.com/gionkunz/chartist-js/blob/master/LICENSE-WTFPL)
 * Plugin originally by: StefanCohen
 * Currently maintained by: j7126 and Willmac16
-* Github Contributors: Andy Harrison (wizard04wsu), Doug Hoyt (doughoyt), Olli (OllisGit), OverLoad (overload08), spiff72, CynanX, Klammerson, 0xz00n, cp2004
+* Github Contributors: Andy Harrison (wizard04wsu), Doug Hoyt (doughoyt), Olli (OllisGit), OverLoad (overload08), spiff72, CynanX, Klammerson, 0xz00n, cp2004, clonesht
 * Community support and encouragement: OutsourcedGuru, jneilliii, foosel
 
 ## Support OctoPrint

--- a/octoprint_dashboard/static/js/dashboard.js
+++ b/octoprint_dashboard/static/js/dashboard.js
@@ -63,6 +63,7 @@ $(function() {
         self.flipH = ko.observable(0);
         self.flipV = ko.observable(0);
         self.isFull = ko.observable(false);
+        self.isTabVisible = ko.observable(false);
 
         // Gauge Rendering vars
         self.tempGaugeAngle = ko.observable(260);
@@ -531,7 +532,7 @@ $(function() {
         };
 
         self.embedUrl = function() {
-            if (self.webcamState() > 0 && self.settingsViewModel.settings.webcam && self.settingsViewModel.settings.plugins.dashboard.showWebCam() == true) {
+            if (self.webcamState() > 0 && self.settingsViewModel.settings.webcam && self.settingsViewModel.settings.plugins.dashboard.showWebCam() == true && self.isTabVisible()) {
                 if (self.settingsViewModel.settings.plugins.dashboard.enableDashMultiCam()) {
                     var webcamIndex = self.webcamState() - 1;
                     var webcam = self.settingsViewModel.settings.plugins.dashboard._webcamArray()[webcamIndex];
@@ -712,6 +713,12 @@ $(function() {
             self.onTabChange = function(current, previous) {
                 self.layerProgress_onTabChange(current, previous);
                 self.lastTab = previous;
+
+                if (current == "#tab_plugin_dashboard") {
+                    self.isTabVisible(true);
+                } else if (previous == "#tab_plugin_dashboard") {
+                    self.isTabVisible(false);
+                };
             };
         }
 

--- a/octoprint_dashboard/static/js/dashboard.js
+++ b/octoprint_dashboard/static/js/dashboard.js
@@ -976,6 +976,15 @@ $(function() {
             self.layerGraph = new Chartist.Line('.ct-chart');
 
             self.doTempGaugeTicks();
+
+            document.addEventListener("visibilitychange", () => {
+                console.log(document.visibilityState);
+                if (document.visibilityState == 'visible') {
+                    self.isTabVisible(true);
+                } else {
+                    self.isTabVisible(false);
+                }
+            });
         }
 
     };


### PR DESCRIPTION
Webcam mjpeg streams are pretty bandwidth heavy, so better to disable if it's not visible.

Possible future enhancements:

 - Webcam hide stream timeout (like the normal webcam tab)
 -  Also disable the stream if the browser tab is not active (using `document.addEventListener("visibilitychange", onchange);`)