### PR TITLE
Change Full browser link to A html tag

### DIFF
--- a/octoprint_dashboard/static/js/dashboard.js
+++ b/octoprint_dashboard/static/js/dashboard.js
@@ -173,6 +173,16 @@ $(function() {
             }
         };
 
+        self.getToggleFullBrowserWindowHref = function() {
+            var urlParams = new URLSearchParams(self.urlParams);
+            if (!dashboardIsFull) {
+                urlParams.set('dashboard', 'full');
+            } else {
+                urlParams.delete('dashboard');
+            }
+            return "?" + urlParams.toString() + "#tab_plugin_dashboard";
+        }
+
 
         self.toggleFullBrowserWindow = function() {
             if (!dashboardIsFull) {
@@ -976,6 +986,7 @@ $(function() {
             self.layerGraph = new Chartist.Line('.ct-chart');
 
             self.doTempGaugeTicks();
+
 
             document.addEventListener("visibilitychange", () => {
                 console.log(document.visibilityState);

--- a/octoprint_dashboard/static/js/dashboard.js
+++ b/octoprint_dashboard/static/js/dashboard.js
@@ -987,7 +987,6 @@ $(function() {
 
             self.doTempGaugeTicks();
 
-
             document.addEventListener("visibilitychange", () => {
                 console.log(document.visibilityState);
                 if (document.visibilityState == 'visible') {

--- a/octoprint_dashboard/templates/dashboard_tab.jinja2
+++ b/octoprint_dashboard/templates/dashboard_tab.jinja2
@@ -2,9 +2,10 @@
   <div class="dashboardFsContainer"
     data-bind="attr: {id: 'dashboardFsContainer_webcam_' + (settingsViewModel.settings.plugins.dashboard.showWebCam() && fsWebCam() && webcamState() != 0)}">
 
-    <input class="dashboardIcon" id="fullWindowIcon" title="Full Browser Window" type="image"
-      src="plugin/dashboard/static/img/fullwindow-icon.png"
-      data-bind="click: toggleFullBrowserWindow,  visible: settingsViewModel.settings.plugins.dashboard.showFullscreen()" />
+    <a id="fullWindowIconLink" title="Full Browser Window" href="#"
+       data-bind="click: toggleFullBrowserWindow, visible: settingsViewModel.settings.plugins.dashboard.showFullscreen(), attr: {href: getToggleFullBrowserWindowHref()}">
+     <img class="dashboardIcon" id="fullWindowIcon" src="plugin/dashboard/static/img/fullwindow-icon.png"/>
+    </a>
     <input class="dashboardIcon" id="fullScreenIcon" title="Fullscreen (Esc to cancel)" type="image"
       src="plugin/dashboard/static/img/fullscreen-icon.png"
       data-bind="click: fullScreen, visible: settingsViewModel.settings.plugins.dashboard.showFullscreen()" />


### PR DESCRIPTION
Use `<a href="...` html tag to to display the "Full Browser Window" button instead of `<input ...`, so it can be opened to a new window/tab. Tested on FF+Chrome on Win10.