### PR TITLE
Disable webcam localhost

### DIFF
--- a/octoprint_dashboard/__init__.py
+++ b/octoprint_dashboard/__init__.py
@@ -246,6 +246,7 @@ class DashboardPlugin(octoprint.plugin.SettingsPlugin,
 			useThemeifyColor=True,
 			showCommandWidgets=False,
 			disableWebcamNonce=False,
+			disableWebcamLocal=False,
 			commandWidgetArray=[dict(
 					icon='command-icon.png',
 					name='Default',

--- a/octoprint_dashboard/static/js/dashboard.js
+++ b/octoprint_dashboard/static/js/dashboard.js
@@ -532,7 +532,7 @@ $(function() {
 
         self.embedUrl = function() {
             if (self.webcamState() > 0 && self.settingsViewModel.settings.webcam && self.settingsViewModel.settings.plugins.dashboard.showWebCam() == true) {
-                if (self.settingsViewModel.settings.plugins.dashboard.disableWebcamLocal() && (window.location.href.match('127.0.0.1') || window.location.href.match('localhost'))) {
+                if (self.settingsViewModel.settings.plugins.dashboard.disableWebcamLocal() && ['127.0.0.1', 'localhost'].includes(window.location.host.split(':')[0])) {
                     return "";
                 }
                 if (self.settingsViewModel.settings.plugins.dashboard.enableDashMultiCam()) {

--- a/octoprint_dashboard/static/js/dashboard.js
+++ b/octoprint_dashboard/static/js/dashboard.js
@@ -533,6 +533,7 @@ $(function() {
         self.embedUrl = function() {
             if (self.webcamState() > 0 && self.settingsViewModel.settings.webcam && self.settingsViewModel.settings.plugins.dashboard.showWebCam() == true) {
                 if (self.settingsViewModel.settings.plugins.dashboard.disableWebcamLocal() && ['127.0.0.1', 'localhost'].includes(window.location.host.split(':')[0])) {
+                    self.toggleWebcam();
                     return "";
                 }
                 if (self.settingsViewModel.settings.plugins.dashboard.enableDashMultiCam()) {

--- a/octoprint_dashboard/static/js/dashboard.js
+++ b/octoprint_dashboard/static/js/dashboard.js
@@ -532,6 +532,9 @@ $(function() {
 
         self.embedUrl = function() {
             if (self.webcamState() > 0 && self.settingsViewModel.settings.webcam && self.settingsViewModel.settings.plugins.dashboard.showWebCam() == true) {
+                if (self.settingsViewModel.settings.plugins.dashboard.disableWebcamLocal() && (window.location.href.match('127.0.0.1') || window.location.href.match('localhost'))) {
+                    return "";
+                }
                 if (self.settingsViewModel.settings.plugins.dashboard.enableDashMultiCam()) {
                     var webcamIndex = self.webcamState() - 1;
                     var webcam = self.settingsViewModel.settings.plugins.dashboard._webcamArray()[webcamIndex];
@@ -833,6 +836,7 @@ $(function() {
             }
 
             try {
+                if (window.location.href.match('127.0.0.1'))  { $('#webcam_toggle').remove() })
                 self.webcam_perm(self.loginState.userneeds().role.includes('webcam'));
             }
             catch {

--- a/octoprint_dashboard/static/js/dashboard.js
+++ b/octoprint_dashboard/static/js/dashboard.js
@@ -836,7 +836,6 @@ $(function() {
             }
 
             try {
-                if (window.location.href.match('127.0.0.1'))  { $('#webcam_toggle').remove() })
                 self.webcam_perm(self.loginState.userneeds().role.includes('webcam'));
             }
             catch {

--- a/octoprint_dashboard/templates/dashboard_settings.jinja2
+++ b/octoprint_dashboard/templates/dashboard_settings.jinja2
@@ -358,7 +358,7 @@
                         </div>
                         <br />
                         <div>
-                            <label class="checkbox">{{ _('Disable Octoprint webcam when viewing @ localhost or 127.0.0.1 (saves big on pi resources in the chromium renderer)') }}
+                            <label class="checkbox">{{ _('Disable Octoprint webcam when viewing @ localhost or 127.0.0.1') }}
                                 <input type="checkbox"
                                     data-bind="checked: settingsViewModel.settings.plugins.dashboard.disableWebcamLocal">
                             </label>

--- a/octoprint_dashboard/templates/dashboard_settings.jinja2
+++ b/octoprint_dashboard/templates/dashboard_settings.jinja2
@@ -358,6 +358,13 @@
                         </div>
                         <br />
                         <div>
+                            <label class="checkbox">{{ _('Disable Octoprint webcam when viewing @ localhost or 127.0.0.1 (saves big on pi resources in the chromium renderer)') }}
+                                <input type="checkbox"
+                                    data-bind="checked: settingsViewModel.settings.plugins.dashboard.disableWebcamLocal">
+                            </label>
+                        </div>
+                        <br />
+                        <div>
                             <label class="checkbox">{{ _('Enable Dashboard Multi Webcams') }}
                                 <input type="checkbox"
                                     data-bind="checked: settingsViewModel.settings.plugins.dashboard.enableDashMultiCam">


### PR DESCRIPTION
I was having trouble with resource consumption in chromium on the local Pi, while viewing the dashboard with a webcam stream. Sometimes running out of resources before I could even click the webcam button to hide it.  

This adds a configuration option (default false) in the plugin settings for "webcam" to suppress the webcam view when the browser host is either `localhost` or `127.0.0.1`.  I only need the webcam view for remote requests.