### PR TITLE
Calculate extruded filament for G2/G3

### DIFF
--- a/octoprint_dashboard/__init__.py
+++ b/octoprint_dashboard/__init__.py
@@ -441,7 +441,7 @@ class DashboardPlugin(octoprint.plugin.SettingsPlugin,
 				self.extruded_filament_arr.append(self.extruded_filament)
 			else: return
 
-		elif gcode in ("G0", "G1"):
+		elif gcode in ("G0", "G1", "G2", "G3"):
 			CmdDict = dict ((x,float(y)) for d,x,y in (re.split('([A-Z])', i) for i in cmd.upper().split()))
 			if "E" in CmdDict:
 				e = float(CmdDict["E"])


### PR DESCRIPTION
When using this plugin with [Arc Welder](https://github.com/FormerLurker/ArcWelderPlugin) the extruded filament on arc moves was not calculated causing the value in the widget to be lower than what the firmware reported.

The fix has been tested and it works.