### PR TITLE
Fix temperature units for enclosure plugin integration

### DIFF
--- a/octoprint_dashboard/templates/dashboard_tab.jinja2
+++ b/octoprint_dashboard/templates/dashboard_tab.jinja2
@@ -244,8 +244,14 @@
           src="plugin/dashboard/static/img/ambient-sensor-icon.png">
         <div class="inline">
           <span id="HumiditySensorInfo" data-bind="text: label, attr: {title: label}"></span><br />
+          <!-- ko if: use_fahrenheit -->
+          <span id="TempSensorInfo"
+            data-bind="attr: { title: 'Ambient Temp Sensor' }, html: temp_sensor_temp() + '°F'"></span>
+          <!-- /ko -->
+          <!-- ko if: !(use_fahrenheit) -->
           <span id="TempSensorInfo"
             data-bind="attr: { title: 'Ambient Temp Sensor' }, html: temp_sensor_temp() + '°C'"></span>
+          <!-- /ko -->
           <!-- ko if: temp_sensor_humidity -->
           <span class="dashboardSmall" id="HumiditySensorInfo"
             data-bind="attr: { title: 'Ambient Humidity Sensor' }, html: temp_sensor_humidity() + '%'"></span>

--- a/octoprint_dashboard/templates/dashboard_tab.jinja2
+++ b/octoprint_dashboard/templates/dashboard_tab.jinja2
@@ -248,7 +248,7 @@
           <span id="TempSensorInfo"
             data-bind="attr: { title: 'Ambient Temp Sensor' }, html: temp_sensor_temp() + '°F'"></span>
           <!-- /ko -->
-          <!-- ko if: !(use_fahrenheit) -->
+          <!-- ko ifnot: use_fahrenheit -->
           <span id="TempSensorInfo"
             data-bind="attr: { title: 'Ambient Temp Sensor' }, html: temp_sensor_temp() + '°C'"></span>
           <!-- /ko -->


### PR DESCRIPTION
The existing dashboard jinja template has a hard-coded "C" temperature unit, even when the enclosure plugin is set to Fahrenheit mode.

This PR fixes that, and sets it to "F" based on the enclosure plugin settings.