### PR TITLE
Fix saving metadata for files in subfolders

### DIFF
--- a/octoprint_dashboard/__init__.py
+++ b/octoprint_dashboard/__init__.py
@@ -374,7 +374,7 @@ class DashboardPlugin(octoprint.plugin.SettingsPlugin,
 		self._logger.info("GcodePreProcessor found filament changes: " + str(len(processor.filament_change_array)))
 		self._logger.info("GcodePreProcessor saving layer count in file metadata")
 		additionalMetaData = {"layer_move_array": json.dumps(processor.layer_move_array), "filament_change_array": json.dumps(processor.filament_change_array)}
-		self._file_manager.set_additional_metadata(payload.get("origin"), payload.get("name"), self._plugin_info.key, additionalMetaData, overwrite=True)
+		self._file_manager.set_additional_metadata(payload.get("origin"), payload.get("path"), self._plugin_info.key, additionalMetaData, overwrite=True)
 
 	def load_from_meta(self, payload):
 			#Reset vars


### PR DESCRIPTION
I noticed Octoprint-Dashboard was causing very high CPU usage during prints, and it seemed to be looping preprocessing the gcode infinitely. Eventually found as my GCode was in a subfolder, it was not correctly saving the metadata and looping constantly reanalysing the gcode (even during print! causing stuttering)

This quick fix has solved the problem, the save_additional_metadata call now uses the path, as get_metadata does.