### PR TITLE
narrow scope of svg text style

### DIFF
--- a/octoprint_dashboard/templates/dashboard_tab.jinja2
+++ b/octoprint_dashboard/templates/dashboard_tab.jinja2
@@ -23,7 +23,7 @@
   <style id="dashboard_theme_color_tag"
     data-bind="html: '.ct-series-a .ct-line, .dashboardGauge, .dashboardGridItem.speed svg path#t2 { stroke: ' + accentColor() + '!important; }' +
                       '.ct-chart span, .dashboardSmall, .dashboardLarge { color: ' + accentColor() + '!important; }' +
-                      'svg text, .dashboardGridItem.speed svg path#t1, .dashboardGridItem.speed svg circle, #dashboardFeedrate5Avg, #dashboardFeedrateLive { stroke: ' + accentColor() + '!important; fill: ' + accentColor() + '!important; }' +
+                      '.dashboardContainer svg text, .dashboardGridItem.speed svg path#t1, .dashboardGridItem.speed svg circle, #dashboardFeedrate5Avg, #dashboardFeedrateLive { stroke: ' + accentColor() + '!important; fill: ' + accentColor() + '!important; }' +
                       '.dashboardTempTick { stroke: ' + textColor() + '!important; }'">
   </style>
   <div class="dashboardFsContainer"


### PR DESCRIPTION
The dashboard plugin applies the theme accent color to the `stroke` and `fill` attributes of `svg text`.
This `<style>` declaration is marked as `!important`, so it overrides other styles and plugins.

In particular, this conflict affects the graph produced by https://plugins.octoprint.org/plugins/plotlytempgraph/


This PR simply adds a scope (the top level `dashboardContainer`) to the css selector so it applies only to this plugin's html.