### PR TITLE
Fix webcam nonce and query params

### DIFF
--- a/octoprint_dashboard/static/js/dashboard.js
+++ b/octoprint_dashboard/static/js/dashboard.js
@@ -690,7 +690,8 @@ $(function () {
                             var webcam = self.dashboardSettings._webcamArray()[webcamIndex];
 
                             var url = webcam.url();
-                            var nonce = webcam.disableNonce() ? '' : '?nonce_dashboard=' + new Date().getTime();
+                            var nonce_separator = url.includes('?') ? '&' : '?';
+                            var nonce = webcam.disableNonce() ? '' : nonce_separator + 'nonce_dashboard=' + new Date().getTime();
 
                             self.rotate(webcam.rotate());
                             self.flipH(webcam.flipH());
@@ -700,8 +701,9 @@ $(function () {
                             self.flipH(self.settingsViewModel.settings.webcam.flipH());
                             self.flipV(self.settingsViewModel.settings.webcam.flipV());
 
-                            var nonce = self.dashboardSettings.disableWebcamNonce() ? '' : '?nonce_dashboard=' + new Date().getTime();
                             var url = self.settingsViewModel.settings.webcam.streamUrl();
+                            var nonce_separator = url.includes('?') ? '&' : '?';
+                            var nonce = self.dashboardSettings.disableWebcamNonce() ? '' : nonce_separator + 'nonce_dashboard=' + new Date().getTime();
                         }
 
                         let streamType = "mjpg";


### PR DESCRIPTION
If we have a query param in webcam URL, the nonce will break it.

Exemple URL: `http://192.168.1.39:8080/?action=stream`
Without the fixe: `http://192.168.1.39:8080/?action=stream?nonce=[...]` => not valid URL 💣
With the fixe: `http://192.168.1.39:8080/?action=stream&nonce=[...]` => valid URL 👌

PS: I don't know how to test it
